### PR TITLE
Fixing day parts

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -314,6 +314,7 @@ document.getElementById('Palindromes').innerHTML = palindromesLeaderboardStr + '
 // DAYS COUNTED
 // QUITE SLOW
 var date = chat[chat.length - 1].created_utc + 86400;
+date = date - (date % 86400);
 var DaysCountedArr = {};
 var DaysCountedLeaderboard = {};
 for(var i = l - 1; i >= 0; i--) {


### PR DESCRIPTION
Day parts were based on the first count made instead of midnight utc

The added line changes date from x + n * 86400 to just n * 86400 so it'll always be midnight utc

Edgecase would be that the first count was made at midnight, in which case it would have worked correct before and it would work identically now